### PR TITLE
Increase Compiler Version to 4.8

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -28,7 +28,7 @@ endif
 # Android NDK setup
 NDK_BASE ?= /opt/android-ndk
 NDK_ABI=arm
-NDK_COMPILER_VERSION=4.6
+NDK_COMPILER_VERSION=4.8
 # NDK platform level, aka APP_PLATFORM, is equivalent to minSdkVersion
 NDK_PLATFORM_LEVEL ?= \
 	$(shell sed -n 's,.*android:minSdkVersion="\([0-9][0-9]*\)".*,\1,p' $(PROJECT_ROOT)/AndroidManifest.xml)


### PR DESCRIPTION
4.6 is being deprecated (From latest NDK changelog:  "Deprecated GCC 4.6, and will remove it next release.")
